### PR TITLE
index on startup

### DIFF
--- a/docker-demos/feature-set-7.2-sp1/mount/files/portal-ext.properties
+++ b/docker-demos/feature-set-7.2-sp1/mount/files/portal-ext.properties
@@ -14,6 +14,7 @@ auth.login.url=/web/guest/login
 layout.show.portlet.access.denied=false
 
 database.indexes.update.on.startup=true
+index.on.startup=true
 
 velocity.engine.restricted.variables=
 freemarker.engine.restricted.variables=


### PR DESCRIPTION
We're restoring a database and need to reindex at least once. As there's not a lot of content, it doesn't hurt too much to index on every startup. Without reindexing, user list in control panel shows an empty list.